### PR TITLE
Fix incorrect spelling of mimetype

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,13 +57,13 @@ var config = {
       loader: ExtractTextPlugin.extract('style-loader', 'css-loader!less-loader')
     }, {
       test: /\.png$/,
-      loader: 'url-loader?limit=10000&minetype=image/png'
+      loader: 'url-loader?limit=10000&mimetype=image/png'
     }, {
       test: /\.woff(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-      loader: 'url-loader?limit=10000&minetype=application/font-woff'
+      loader: 'url-loader?limit=10000&mimetype=application/font-woff'
     }, {
       test: /\.woff2(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-      loader: 'url-loader?limit=10000&minetype=application/font-woff2'
+      loader: 'url-loader?limit=10000&mimetype=application/font-woff2'
     }, {
       test: /\.(otf|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
       loader: 'file-loader'


### PR DESCRIPTION
Earlier releases of url-loader had this typo, but we can now spell it
correctly.
